### PR TITLE
Fixed TmTheme scope issue for monaco-editor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Registry, StackElement, INITIAL } from 'monaco-textmate'
 import * as monacoNsps from 'monaco-editor'
+import { TMToMonacoToken } from './tm-to-monaco-token';
 
 class TokenizerState implements monacoNsps.languages.IState {
 
@@ -34,7 +35,7 @@ class TokenizerState implements monacoNsps.languages.IState {
  * @param registry TmGrammar `Registry` this wiring should rely on to provide the grammars
  * @param languages `Map` of language ids (string) to TM names (string)
  */
-export function wireTmGrammars(monaco: typeof monacoNsps, registry: Registry, languages: Map<string, string>) {
+export function wireTmGrammars(monaco: typeof monacoNsps, registry: Registry, languages: Map<string, string>, editor?: monacoNsps.editor.ICodeEditor) {
     return Promise.all(
         Array.from(languages.keys())
             .map(async (languageId) => {
@@ -48,7 +49,7 @@ export function wireTmGrammars(monaco: typeof monacoNsps, registry: Registry, la
                             tokens: res.tokens.map(token => ({
                                 ...token,
                                 // TODO: At the moment, monaco-editor doesn't seem to accept array of scopes
-                                scopes: token.scopes[token.scopes.length - 1]
+                                scopes: editor ? TMToMonacoToken(editor, token.scopes) : token.scopes[token.scopes.length - 1]
                             })),
                         }
                     }

--- a/src/tm-to-monaco-token.ts
+++ b/src/tm-to-monaco-token.ts
@@ -1,0 +1,53 @@
+import * as monacoNsps from 'monaco-editor'
+
+// as described in issue: https://github.com/NeekSandhu/monaco-textmate/issues/5
+export const TMToMonacoToken = (editor: monacoNsps.editor.ICodeEditor, scopes: string[]) => {
+    let scopeName = "";
+    // get the scope name. Example: cpp , java, haskell
+    for (let i = scopes[0].length - 1; i >= 0; i -= 1) {
+        const char = scopes[0][i];
+        if (char === ".") {
+            break;
+        }
+        scopeName = char + scopeName;
+    }
+
+    // iterate through all scopes from last to first
+    for (let i = scopes.length - 1; i >= 0; i -= 1) {
+        const scope = scopes[i];
+
+        /**
+         * Try all possible tokens from high specific token to low specific token
+         *
+         * Example:
+         * 0 meta.function.definition.parameters.cpp
+         * 1 meta.function.definition.parameters
+         *
+         * 2 meta.function.definition.cpp
+         * 3 meta.function.definition
+         *
+         * 4 meta.function.cpp
+         * 5 meta.function
+         *
+         * 6 meta.cpp
+         * 7 meta
+         */
+        for (let i = scope.length - 1; i >= 0; i -= 1) {
+            const char = scope[i];
+            if (char === ".") {
+                const token = scope.slice(0, i);
+                if (
+                    editor['_themeService'].getTheme()._tokenTheme._match(token + "." + scopeName)._foreground >
+                    1
+                ) {
+                    return token + "." + scopeName;
+                }
+                if (editor['_themeService'].getTheme()._tokenTheme._match(token)._foreground > 1) {
+                    return token;
+                }
+            }
+        }
+    }
+
+    return "";
+};


### PR DESCRIPTION
Fixes issue: https://github.com/NeekSandhu/monaco-textmate/issues/5

API maintains backward compatibility. Optionally pass editor instance to
 `wireTmGrammars(...args, editor)` to filter for appropriate token scope.

__Implementation borrowed from: https://github.com/NeekSandhu/monaco-textmate/issues/5#issuecomment-496412139__

### Before:
![monaco-textmate-old](https://user-images.githubusercontent.com/32554850/59548877-c5422180-8f72-11e9-9589-3d4066fd1460.png)

### After: 
![monaco-textmate-corrected](https://user-images.githubusercontent.com/32554850/59548894-d55a0100-8f72-11e9-8645-fb92d6e0aa54.png)

